### PR TITLE
Add branch filtering

### DIFF
--- a/lib/lita/handlers/travis.rb
+++ b/lib/lita/handlers/travis.rb
@@ -33,7 +33,7 @@ module Lita
         begin
           MultiJson.load(json)
         rescue MultiJson::LoadError => e
-          Lita.logger.error(t("parse_error", message: e.message))
+          Lita.logger.error("parse_error, message: #{e.message}")
           return
         end
       end
@@ -70,14 +70,14 @@ module Lita
         elsif default_rooms
           Array(default_rooms)
         else
-          Lita.logger.warn(t("no_room_configured"), repo: repo)
+          Lita.logger.warn("no_room_configured: ignored because no rooms were specified")
           return
         end
       end
 
       def validate_repo(repo, auth_hash)
         unless Digest::SHA2.hexdigest("#{repo}#{config.token}") == auth_hash
-          Lita.logger.warn(t("auth_failed"), repo: repo)
+          Lita.logger.warn("auth_failed: did not pass authentication")
           return
         end
 

--- a/lita-travis.gemspec
+++ b/lita-travis.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", ">= 3.0.0"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "coveralls"
+  spec.add_development_dependency "pry"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,5 +8,6 @@ SimpleCov.start { add_filter "/spec/" }
 
 require "lita-travis"
 require "lita/rspec"
+require "pry"
 
 Lita.version_3_compatibility_mode = false


### PR DESCRIPTION
This allows someone to add a `branch` option to their
config and only get notifications for that branch.